### PR TITLE
feat: add resuming handler and generic player support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"@nestjs/common": "^10.2.0 || ^11.0.0",
 		"@nestjs/core": "^10.2.0 || ^11.0.0",
 		"discord.js": "^14.0.1",
-		"lavalink-client": "^2.4.0",
+		"lavalink-client": "^2.6.1",
 		"necord": "^6.0.0",
 		"reflect-metadata": "^0.2.1",
 		"rxjs": "^7.2.0"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { PlayerStore } from './player.token';

--- a/src/constants/player.token.ts
+++ b/src/constants/player.token.ts
@@ -1,0 +1,1 @@
+export const PlayerStore = Symbol('PlayerStore');

--- a/src/helpers/base-store.ts
+++ b/src/helpers/base-store.ts
@@ -1,0 +1,9 @@
+export abstract class BaseStore {
+	public abstract save(key: string, value: any): Promise<void>;
+
+	public abstract delete(key: string): Promise<void>;
+
+	public abstract get(key: string): Promise<any>;
+
+	public abstract getAll(): Promise<{ key: string; value: string }[]>;
+}

--- a/src/helpers/handle-resuming.ts
+++ b/src/helpers/handle-resuming.ts
@@ -1,0 +1,97 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { LavalinkManager, NodeManager } from 'lavalink-client';
+import { PlayerManager } from './player-manager';
+import { Client } from 'discord.js';
+import { LAVALINK_MODULE_OPTIONS } from '../necord-lavalink.module-definition';
+import { NecordLavalinkModuleOptions } from '../necord-lavalink-options.interface';
+import { PlayerStore } from '../constants';
+import { BaseStore } from './base-store';
+import { PlayerSaver } from './player-saver';
+
+@Injectable()
+export class ResumingHandler {
+	public constructor(
+		private readonly nodeManager: NodeManager,
+		private readonly playerManager: PlayerManager,
+		private readonly lavalinkManager: LavalinkManager,
+		private readonly client: Client,
+		private readonly playerSaver: PlayerSaver,
+		@Inject(PlayerStore)
+		private readonly store: BaseStore,
+		@Inject(LAVALINK_MODULE_OPTIONS)
+		private readonly lavalinkOptions: NecordLavalinkModuleOptions
+	) {}
+
+	private readonly logger = new Logger('ResumingHandler');
+
+	public async resume() {
+		this.lavalinkManager.on('playerCreate', async player => {
+			await this.playerSaver.savePlayerOnCreate(player);
+		});
+
+		this.lavalinkManager.on('playerUpdate', async (oldPlayer, newPlayer) => {
+			await this.playerSaver.savePlayerOnUpdate(oldPlayer, newPlayer);
+		});
+
+		this.lavalinkManager.on('playerDestroy', async (player, reason) => {
+			await this.playerSaver.deletePlayer(player.guildId);
+		});
+
+		this.nodeManager.on('connect', async node => {
+			await node.updateSession(true, this.lavalinkOptions.autoResume.timer ?? 360e3);
+		});
+
+		this.nodeManager.on('resumed', async (node, payload, players) => {
+			if (!Array.isArray(players)) {
+				this.logger.log(`Node: \`${node.id}\` has no players to resume`);
+				return;
+			}
+
+			this.logger.log(`Node: \`${node.id}\` started resuming ${players.length} players`);
+
+			for (const playerData of players) {
+				const savedPlayer = await this.store.get(playerData.guildId);
+
+				if (!playerData.state.connected) {
+					await this.store.delete(playerData.guildId);
+				}
+
+				const player = this.playerManager.create({
+					guildId: playerData.guildId,
+					voiceChannelId: savedPlayer.voiceChannelId,
+					textChannelId: savedPlayer.textChannelId,
+					selfDeaf: savedPlayer.options?.selfDeaf || true,
+					selfMute: savedPlayer.options?.selfMute || false,
+					volume: this.lavalinkOptions.playerOptions?.volumeDecrementer
+						? Math.round(
+								playerData.volume /
+									this.lavalinkOptions.playerOptions.volumeDecrementer
+							)
+						: playerData.volume,
+					node: node.id,
+					applyVolumeAsFilter: savedPlayer.options.applyVolumeAsFilter,
+					instaUpdateFiltersFix: savedPlayer.options.instaUpdateFiltersFix,
+					vcRegion: savedPlayer.options.vcRegion
+				});
+
+				await player.connect();
+
+				player.filterManager.data = playerData.filters;
+				await player.queue.utils.sync(true, false).catch(console.warn);
+				if (playerData.track)
+					player.queue.current = this.lavalinkManager.utils.buildTrack(
+						playerData.track,
+
+						player.queue.current?.requester || this.client.user
+					);
+				player.lastPosition = playerData.state.position;
+				player.lastPositionChange = Date.now();
+				player.ping.lavalink = playerData.state.ping;
+				player.paused = playerData.paused;
+				player.playing = !playerData.paused && !!playerData.track;
+			}
+
+			this.logger.log(`Node: \`${node.id}\` finished resuming ${players.length} players`);
+		});
+	}
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,4 @@
+export * from './base-store';
+export * from './handle-resuming';
 export * from './player-manager';
+export * from './player-saver';

--- a/src/helpers/player-saver.ts
+++ b/src/helpers/player-saver.ts
@@ -1,0 +1,74 @@
+import { Player, PlayerJson } from 'lavalink-client';
+import { BaseStore } from './base-store';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { PlayerStore } from '../constants';
+
+@Injectable()
+export class PlayerSaver {
+	public constructor(@Inject(PlayerStore) private readonly store: BaseStore) {}
+
+	private readonly logger = new Logger('PlayerSaver');
+
+	public async savePlayerOnUpdate(oldPlayer: PlayerJson, newPlayer: Player): Promise<void> {
+		const newPlayerData = newPlayer.toJSON();
+
+		if (
+			!oldPlayer ||
+			oldPlayer.voiceChannelId !== newPlayerData.voiceChannelId ||
+			oldPlayer.textChannelId !== newPlayerData.textChannelId ||
+			oldPlayer.options.selfDeaf !== newPlayerData.options.selfDeaf ||
+			oldPlayer.options.selfMute !== newPlayerData.options.selfMute ||
+			oldPlayer.nodeId !== newPlayerData.nodeId ||
+			oldPlayer.nodeSessionId !== newPlayerData.nodeSessionId ||
+			oldPlayer.options.applyVolumeAsFilter !== newPlayerData.options.applyVolumeAsFilter ||
+			oldPlayer.options.instaUpdateFiltersFix !==
+				newPlayerData.options.instaUpdateFiltersFix ||
+			oldPlayer.options.vcRegion !== newPlayerData.options.vcRegion
+		) {
+			const id = this.transformId(newPlayerData.guildId);
+			await this.store.save(id, JSON.stringify(newPlayerData));
+		}
+	}
+
+	public async savePlayerOnCreate(player: Player): Promise<void> {
+		const playerData = player.toJSON();
+		const id = this.transformId(playerData.guildId);
+		await this.store.save(id, JSON.stringify(playerData));
+	}
+
+	public async deletePlayer(guildId: string): Promise<void> {
+		const id = this.transformId(guildId);
+		await this.store.delete(id);
+	}
+
+	public async getSessions(): Promise<Map<string, string>> {
+		const sessions = new Map<string, string>();
+
+		const players = await this.store.getAll();
+
+		if (players.length === 0) return new Map();
+
+		try {
+			for (const player of players) {
+				if (player.value) {
+					const rawValue = Buffer.isBuffer(player.value)
+						? player.value.toString('utf-8')
+						: player.value;
+
+					const playerObj = JSON.parse(rawValue) as PlayerJson;
+
+					if (playerObj.nodeSessionId && playerObj.nodeId) {
+						sessions.set(playerObj.nodeId, playerObj.nodeSessionId);
+					}
+				}
+			}
+		} catch (error) {
+			this.logger.error('Error fetching saved player sessions', error);
+			return new Map();
+		}
+	}
+
+	private transformId(guildId: string): string {
+		return `player:${guildId}`;
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './context';
 export * from './helpers';
 export * from './listeners';

--- a/src/necord-lavalink-options.interface.ts
+++ b/src/necord-lavalink-options.interface.ts
@@ -1,5 +1,11 @@
-import { ManagerOptions } from 'lavalink-client';
+import { ManagerOptions, Player } from 'lavalink-client';
+import { BaseStore } from './helpers';
 
-export interface NecordLavalinkModuleOptions extends Omit<ManagerOptions, 'sendToShard'> {
-	sendToShard?: ManagerOptions['sendToShard'];
+export interface NecordLavalinkModuleOptions<T extends Player = Player>
+	extends Omit<ManagerOptions<T>, 'sendToShard'> {
+	sendToShard?: ManagerOptions<T>['sendToShard'];
+	autoResume?: {
+		playerStore: BaseStore;
+		timer?: number;
+	};
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,5 @@
 export * from './lavalink-manager.provider';
 export * from './node-manager.provider';
+export * from './player-store.provider';
+export * from './player-saver.provider';
 export * from './player.provider';

--- a/src/providers/lavalink-manager.provider.ts
+++ b/src/providers/lavalink-manager.provider.ts
@@ -1,17 +1,33 @@
 import { Provider } from '@nestjs/common';
 import { LAVALINK_MODULE_OPTIONS } from '../necord-lavalink.module-definition';
-import { LavalinkManager } from 'lavalink-client';
+import { LavalinkManager, LavalinkNodeOptions, Player } from 'lavalink-client';
 import { NecordLavalinkModuleOptions } from '../necord-lavalink-options.interface';
 import { Client } from 'discord.js';
+import { PlayerSaver } from '../helpers';
 
 export const LavalinkManagerProvider: Provider<LavalinkManager> = {
 	provide: LavalinkManager,
-	useFactory: async (client: Client, options: NecordLavalinkModuleOptions) => {
-		return new LavalinkManager({
+	useFactory: async <T extends Player>(
+		client: Client,
+		options: NecordLavalinkModuleOptions<T>,
+		playerSaver: PlayerSaver
+	) => {
+		let nodes: LavalinkNodeOptions[] = options.nodes;
+
+		if (options.autoResume) {
+			const sessions = await playerSaver.getSessions();
+			nodes = options.nodes?.map(node => ({
+				...node,
+				session: sessions.get(node.id)
+			}));
+		}
+
+		return new LavalinkManager<T>({
+			...options,
+			nodes,
 			sendToShard: (guildId: string, payload: any) =>
-				client.guilds.cache.get(guildId)?.shard?.send(payload),
-			...options
+				client.guilds.cache.get(guildId)?.shard?.send(payload)
 		});
 	},
-	inject: [Client, LAVALINK_MODULE_OPTIONS]
+	inject: [Client, LAVALINK_MODULE_OPTIONS, PlayerSaver]
 };

--- a/src/providers/player-saver.provider.ts
+++ b/src/providers/player-saver.provider.ts
@@ -1,0 +1,9 @@
+import { PlayerStore } from '../constants';
+import { BaseStore } from '../structures/base-store';
+import { PlayerSaver } from '../helpers/player-saver';
+
+export const PlayerSaverProvider = {
+	provide: PlayerSaver,
+	useFactory: (store: BaseStore) => new PlayerSaver(store),
+	inject: [PlayerStore]
+};

--- a/src/providers/player-store.provider.ts
+++ b/src/providers/player-store.provider.ts
@@ -1,0 +1,9 @@
+import { PlayerStore } from '../constants';
+import { NecordLavalinkModuleOptions } from '../necord-lavalink-options.interface';
+import { LAVALINK_MODULE_OPTIONS } from '../necord-lavalink.module-definition';
+
+export const PlayerStoreProvider = {
+	provide: PlayerStore,
+	useFactory: (options: NecordLavalinkModuleOptions) => options.autoResume?.playerStore,
+	inject: [LAVALINK_MODULE_OPTIONS]
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added [resuming handler](https://tomato6966.github.io/lavalink-client/extra/resuming/)
Added support for custom player class from [lastest version of lavalink-client](https://github.com/Tomato6966/lavalink-client/commit/10604f36d05435f0858e68f32ac0f533469142b3)

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
