### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-pkg.pr.new.yml
+++ b/.github/workflows/publish-pkg.pr.new.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - '!**'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Potential fix for [https://github.com/necordjs/lavalink/security/code-scanning/13](https://github.com/necordjs/lavalink/security/code-scanning/13)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default. The best minimal fix (per CodeQL guidance) is to set:

- `contents: read`

at the workflow root level (near `on:` / before `jobs:`), which applies to all jobs unless overridden. This preserves current behavior while documenting and enforcing least privilege.  
File to edit: `.github/workflows/publish-pkg.pr.new.yml`  
Region to change: after the trigger block and before `jobs:`.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
