### PR TITLE
fix(providers): use symbol tokens as DI tokens instead of class references

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,40 @@ export class AppUpdate {
 
 Whenever you need to handle any event data, use the `Context` decorator.
 
+## Injecting Lavalink instances
+
+`LavalinkManager`, `NodeManager` and `ManagerUtils` are provided under dedicated injection tokens, exposed
+through the `@InjectLavalinkManager()`, `@InjectNodeManager()` and `@InjectManagerUtils()` decorators:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { LavalinkManager, ManagerUtils, NodeManager } from 'lavalink-client';
+import { InjectLavalinkManager, InjectManagerUtils, InjectNodeManager } from '@necord/lavalink';
+
+@Injectable()
+export class MusicService {
+    public constructor(
+        @InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager,
+        @InjectNodeManager() private readonly nodeManager: NodeManager,
+        @InjectManagerUtils() private readonly utils: ManagerUtils
+    ) {}
+}
+```
+
+> [!IMPORTANT]
+> Injecting these instances by class type is no longer supported:
+>
+> ```typescript
+> // Does not work anymore
+> public constructor(private readonly nodeManager: NodeManager) {}
+> ```
+>
+> `lavalink-client` ships a CommonJS and an ESM build, so an application that loads it in a different
+> module format than `@necord/lavalink` ends up with two distinct `NodeManager` class objects. Nest
+> matches providers by reference, so injecting by class type would fail with
+> `UnknownDependenciesException`. The tokens are created with `Symbol.for()`, which resolves through the
+> global symbol registry by key and is therefore immune to the package being loaded more than once.
+
 If you want to fully dive into Necord, check out these resources:
 
 * [Necord Wiki](https://necord.org) - Official documentation of Necord.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1841,9 +1841,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1861,9 +1858,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1881,9 +1875,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1901,9 +1892,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1921,9 +1909,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1941,9 +1926,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1961,9 +1943,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1981,9 +1960,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2220,9 +2196,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2240,9 +2213,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2260,9 +2230,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2280,9 +2247,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2300,9 +2264,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2320,9 +2281,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5472,9 +5430,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5496,9 +5451,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5520,9 +5472,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -5544,9 +5493,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
+export * from './lavalink.tokens.js';
 export { PlayerStore } from './player.token.js';

--- a/src/constants/lavalink.tokens.ts
+++ b/src/constants/lavalink.tokens.ts
@@ -1,0 +1,22 @@
+/**
+ * Injection token for the `LavalinkManager` instance.
+ *
+ * Tokens are created through the global symbol registry (`Symbol.for`) so they
+ * are resolved by key instead of by reference. This keeps injection working even
+ * when `lavalink-client` or this package is loaded in more than one module
+ * format (CJS and ESM), which would otherwise produce two distinct tokens.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const LAVALINK_MANAGER = Symbol.for('NECORD_LAVALINK_MANAGER');
+
+/**
+ * Injection token for the `NodeManager` instance.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const LAVALINK_NODE_MANAGER = Symbol.for('NECORD_LAVALINK_NODE_MANAGER');
+
+/**
+ * Injection token for the `ManagerUtils` instance.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const LAVALINK_UTILS = Symbol.for('NECORD_LAVALINK_UTILS');

--- a/src/constants/player.token.ts
+++ b/src/constants/player.token.ts
@@ -1,1 +1,5 @@
-export const PlayerStore = Symbol('PlayerStore');
+/**
+ * Injection token for the player store used by `autoResume`.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const PlayerStore = Symbol.for('NECORD_LAVALINK_PLAYER_STORE');

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './inject.decorator.js';

--- a/src/decorators/inject.decorator.ts
+++ b/src/decorators/inject.decorator.ts
@@ -1,0 +1,36 @@
+import { Inject } from '@nestjs/common';
+
+import {
+	LAVALINK_MANAGER,
+	LAVALINK_NODE_MANAGER,
+	LAVALINK_UTILS,
+	PlayerStore
+} from '../constants/index.js';
+
+/**
+ * Injects the `LavalinkManager` instance.
+ * @returns The parameter/property decorator.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const InjectLavalinkManager = () => Inject(LAVALINK_MANAGER);
+
+/**
+ * Injects the `NodeManager` instance.
+ * @returns The parameter/property decorator.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const InjectNodeManager = () => Inject(LAVALINK_NODE_MANAGER);
+
+/**
+ * Injects the `ManagerUtils` instance.
+ * @returns The parameter/property decorator.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const InjectManagerUtils = () => Inject(LAVALINK_UTILS);
+
+/**
+ * Injects the player store used by `autoResume`.
+ * @returns The parameter/property decorator.
+ * @url https://necord.org/recipes/lavalink
+ */
+export const InjectPlayerStore = () => Inject(PlayerStore);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './constants/index.js';
 export * from './context/index.js';
+export * from './decorators/index.js';
 export * from './helpers/index.js';
 export * from './listeners/index.js';
 export * from './necord-lavalink-options.interface.js';

--- a/src/listeners/listeners.module.ts
+++ b/src/listeners/listeners.module.ts
@@ -2,6 +2,7 @@ import { DiscoveryModule, DiscoveryService, MetadataScanner, Reflector } from '@
 import { LavalinkManager, NodeManager } from 'lavalink-client';
 import { Module, OnModuleInit } from '@nestjs/common';
 
+import { InjectLavalinkManager, InjectNodeManager } from '../decorators/index.js';
 import { LavalinkListenerMeta } from './interfaces/index.js';
 import { LavalinkListener } from './decorators/index.js';
 import { LavalinkHostType } from './enums/index.js';
@@ -18,8 +19,8 @@ export class LavalinkListenersModule implements OnModuleInit {
 		private readonly discoveryService: DiscoveryService,
 		private readonly metadataScanner: MetadataScanner,
 		private readonly reflector: Reflector,
-		private readonly lavalinkManager: LavalinkManager,
-		private readonly nodeManager: NodeManager
+		@InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager,
+		@InjectNodeManager() private readonly nodeManager: NodeManager
 	) {}
 
 	public onModuleInit(): void {

--- a/src/necord-lavalink.module.ts
+++ b/src/necord-lavalink.module.ts
@@ -14,6 +14,7 @@ import {
 	LAVALINK_MODULE_OPTIONS
 } from './necord-lavalink.module-definition.js';
 import { NecordLavalinkModuleOptions } from './necord-lavalink-options.interface.js';
+import { InjectLavalinkManager, InjectNodeManager } from './decorators/index.js';
 import { NecordLavalinkService } from './necord-lavalink.service.js';
 import { LavalinkListenersModule } from './listeners/index.js';
 import * as ProvidersMap from './providers/index.js';
@@ -36,8 +37,8 @@ export class NecordLavalinkModule
 
 	public constructor(
 		private readonly client: Client,
-		private readonly lavalinkManager: LavalinkManager,
-		private readonly nodeManager: NodeManager,
+		@InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager,
+		@InjectNodeManager() private readonly nodeManager: NodeManager,
 		@Inject(LAVALINK_MODULE_OPTIONS)
 		private readonly options: NecordLavalinkModuleOptions
 	) {

--- a/src/necord-lavalink.service.ts
+++ b/src/necord-lavalink.service.ts
@@ -9,11 +9,13 @@ import {
 import { LavalinkManager, Player } from 'lavalink-client';
 import { Injectable } from '@nestjs/common';
 
+import { InjectLavalinkManager } from './decorators/index.js';
+
 @Injectable()
 export class NecordLavalinkService {
 	public constructor(
 		private readonly client: Client,
-		private readonly lavalinkManager: LavalinkManager
+		@InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager
 	) {}
 
 	public lavalinkUtils = this.lavalinkManager.utils;

--- a/src/providers/lavalink-manager.provider.ts
+++ b/src/providers/lavalink-manager.provider.ts
@@ -5,9 +5,10 @@ import { Client } from 'discord.js';
 import { NecordLavalinkModuleOptions } from '../necord-lavalink-options.interface.js';
 import { LAVALINK_MODULE_OPTIONS } from '../necord-lavalink.module-definition.js';
 import { PlayerSaverService } from '../services/index.js';
+import { LAVALINK_MANAGER } from '../constants/index.js';
 
 export const LavalinkManagerProvider: Provider<LavalinkManager> = {
-	provide: LavalinkManager,
+	provide: LAVALINK_MANAGER,
 	useFactory: async (
 		client: Client,
 		options: NecordLavalinkModuleOptions,

--- a/src/providers/lavalink-node-manager.provider.ts
+++ b/src/providers/lavalink-node-manager.provider.ts
@@ -1,8 +1,10 @@
 import { LavalinkManager, NodeManager } from 'lavalink-client';
 import { Provider } from '@nestjs/common';
 
+import { LAVALINK_MANAGER, LAVALINK_NODE_MANAGER } from '../constants/index.js';
+
 export const LavalinkNodeManagerProvider: Provider<NodeManager> = {
-	provide: NodeManager,
+	provide: LAVALINK_NODE_MANAGER,
 	useFactory: (lavalinkManager: LavalinkManager) => lavalinkManager.nodeManager,
-	inject: [LavalinkManager]
+	inject: [LAVALINK_MANAGER]
 };

--- a/src/providers/lavalink-utils.provider.ts
+++ b/src/providers/lavalink-utils.provider.ts
@@ -1,8 +1,10 @@
 import { LavalinkManager, ManagerUtils } from 'lavalink-client';
 import { Provider } from '@nestjs/common';
 
+import { LAVALINK_MANAGER, LAVALINK_UTILS } from '../constants/index.js';
+
 export const LavalinkUtilsProvider: Provider<ManagerUtils> = {
-	provide: ManagerUtils,
+	provide: LAVALINK_UTILS,
 	useFactory: (lavalinkManager: LavalinkManager) => lavalinkManager.utils,
-	inject: [LavalinkManager]
+	inject: [LAVALINK_MANAGER]
 };

--- a/src/services/player-manager.service.ts
+++ b/src/services/player-manager.service.ts
@@ -1,9 +1,13 @@
 import { DestroyReasonsType, LavalinkManager, Player, PlayerOptions } from 'lavalink-client';
 import { Injectable } from '@nestjs/common';
 
+import { InjectLavalinkManager } from '../decorators/index.js';
+
 @Injectable()
 export class PlayerManagerService {
-	public constructor(private readonly lavalinkManager: LavalinkManager) {}
+	public constructor(
+		@InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager
+	) {}
 
 	public get(guildId: string) {
 		return this.lavalinkManager.getPlayer(guildId);

--- a/src/services/player-saver.service.ts
+++ b/src/services/player-saver.service.ts
@@ -1,15 +1,15 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Player, PlayerJson } from 'lavalink-client';
+import { Injectable, Logger } from '@nestjs/common';
 
+import { InjectPlayerStore } from '../decorators/index.js';
 import { normalizeJsonObject } from '../utils/index.js';
 import { BaseStore } from '../helpers/base-store.js';
-import { PlayerStore } from '../constants/index.js';
 
 @Injectable()
 export class PlayerSaverService {
 	private readonly logger = new Logger(PlayerSaverService.name);
 
-	public constructor(@Inject(PlayerStore) private readonly store: BaseStore) {}
+	public constructor(@InjectPlayerStore() private readonly store: BaseStore) {}
 
 	public async savePlayerOnUpdate(
 		oldPlayer: PlayerJson | null,

--- a/src/services/resuming-handler.service.ts
+++ b/src/services/resuming-handler.service.ts
@@ -2,11 +2,15 @@ import { Inject, Injectable, Logger, OnApplicationBootstrap } from '@nestjs/comm
 import { LavalinkManager, NodeManager } from 'lavalink-client';
 import { Client } from 'discord.js';
 
+import {
+	InjectLavalinkManager,
+	InjectNodeManager,
+	InjectPlayerStore
+} from '../decorators/index.js';
 import { NecordLavalinkModuleOptions } from '../necord-lavalink-options.interface.js';
 import { LAVALINK_MODULE_OPTIONS } from '../necord-lavalink.module-definition.js';
 import { PlayerManagerService } from './player-manager.service.js';
 import { PlayerSaverService } from './player-saver.service.js';
-import { PlayerStore } from '../constants/index.js';
 import { BaseStore } from '../helpers/index.js';
 
 @Injectable()
@@ -14,12 +18,12 @@ export class ResumingHandlerService implements OnApplicationBootstrap {
 	private readonly logger = new Logger(ResumingHandlerService.name);
 
 	public constructor(
-		private readonly nodeManager: NodeManager,
+		@InjectNodeManager() private readonly nodeManager: NodeManager,
 		private readonly playerManager: PlayerManagerService,
-		private readonly lavalinkManager: LavalinkManager,
+		@InjectLavalinkManager() private readonly lavalinkManager: LavalinkManager,
 		private readonly client: Client,
 		private readonly playerSaver: PlayerSaverService,
-		@Inject(PlayerStore)
+		@InjectPlayerStore()
 		private readonly store: BaseStore,
 		@Inject(LAVALINK_MODULE_OPTIONS)
 		private readonly lavalinkOptions: NecordLavalinkModuleOptions

--- a/test/constants/lavalink.tokens.spec.ts
+++ b/test/constants/lavalink.tokens.spec.ts
@@ -1,0 +1,30 @@
+import {
+	LAVALINK_NODE_MANAGER,
+	LAVALINK_MANAGER,
+	LAVALINK_UTILS,
+	PlayerStore
+} from '../../src/constants/index.js';
+
+describe('Injection tokens', () => {
+	const tokens: [symbol, string][] = [
+		[LAVALINK_MANAGER, 'NECORD_LAVALINK_MANAGER'],
+		[LAVALINK_NODE_MANAGER, 'NECORD_LAVALINK_NODE_MANAGER'],
+		[LAVALINK_UTILS, 'NECORD_LAVALINK_UTILS'],
+		[PlayerStore, 'NECORD_LAVALINK_PLAYER_STORE']
+	];
+
+	it.each(tokens)('%p should be registered in the global symbol registry', (token, key) => {
+		expect(Symbol.keyFor(token)).toBe(key);
+	});
+
+	it.each(tokens)('%p should be resolved by key, not by reference', (token, key) => {
+		expect(Symbol.for(key)).toBe(token);
+		expect(Symbol(key)).not.toBe(token);
+	});
+
+	it('should not share tokens between different keys', () => {
+		const keys = tokens.map(([, key]) => key);
+
+		expect(new Set(keys).size).toBe(keys.length);
+	});
+});

--- a/test/listeners/listeners.module.spec.ts
+++ b/test/listeners/listeners.module.spec.ts
@@ -1,8 +1,9 @@
 import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
-import { LavalinkManager, NodeManager } from 'lavalink-client';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import {
+	LAVALINK_MANAGER,
+	LAVALINK_NODE_MANAGER,
 	LavalinkHostType,
 	LavalinkListenersModule,
 	LavalinkListenerType
@@ -61,11 +62,11 @@ describe('LavalinkListenersModule', () => {
 					useValue: reflector
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: lavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: nodeManager
 				}
 			]

--- a/test/necord-lavalink.module.spec.ts
+++ b/test/necord-lavalink.module.spec.ts
@@ -1,12 +1,13 @@
-import { LavalinkManager, NodeManager } from 'lavalink-client';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Client } from 'discord.js';
 
 import {
 	NecordLavalinkModuleOptions,
 	NecordLavalinkModule,
+	LAVALINK_NODE_MANAGER,
 	LAVALINK_MODULE_OPTIONS,
-	ResumingHandlerService
+	ResumingHandlerService,
+	LAVALINK_MANAGER
 } from '../src/index.js';
 
 describe('NecordLavalinkModule', () => {
@@ -75,11 +76,11 @@ describe('NecordLavalinkModule', () => {
 					useValue: mockClient
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: mockLavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: mockNodeManager
 				},
 				{
@@ -176,11 +177,11 @@ describe('NecordLavalinkModule', () => {
 					useValue: mockClient
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: mockLavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: mockNodeManager
 				},
 				{
@@ -230,11 +231,11 @@ describe('NecordLavalinkModule', () => {
 					useValue: mockClient
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: mockLavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: mockNodeManager
 				},
 				{
@@ -282,11 +283,11 @@ describe('NecordLavalinkModule', () => {
 					useValue: mockClient
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: mockLavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: mockNodeManager
 				},
 				{
@@ -337,11 +338,11 @@ describe('NecordLavalinkModule', () => {
 					useValue: mockClient
 				},
 				{
-					provide: LavalinkManager,
+					provide: LAVALINK_MANAGER,
 					useValue: mockLavalinkManager
 				},
 				{
-					provide: NodeManager,
+					provide: LAVALINK_NODE_MANAGER,
 					useValue: mockNodeManager
 				},
 				{

--- a/test/providers/lavalink-manager.provider.spec.ts
+++ b/test/providers/lavalink-manager.provider.spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LavalinkManager } from 'lavalink-client';
 import { Client } from 'discord.js';
 
+import { LAVALINK_MANAGER, LAVALINK_MODULE_OPTIONS, PlayerSaverService } from '../../src/index.js';
 import { LavalinkManagerProvider } from '../../src/providers/lavalink-manager.provider.js';
-import { LAVALINK_MODULE_OPTIONS, PlayerSaverService } from '../../src/index.js';
 
 describe('LavalinkManagerProvider', () => {
 	let moduleRef: TestingModule;
@@ -54,7 +54,7 @@ describe('LavalinkManagerProvider', () => {
 			]
 		}).compile();
 
-		const lavalinkManager = moduleRef.get<LavalinkManager>(LavalinkManager);
+		const lavalinkManager = moduleRef.get<LavalinkManager>(LAVALINK_MANAGER);
 		expect(lavalinkManager).toBeInstanceOf(LavalinkManager);
 		expect(mockPlayerSaver.getSessions).not.toHaveBeenCalled();
 	});
@@ -86,7 +86,7 @@ describe('LavalinkManagerProvider', () => {
 			]
 		}).compile();
 
-		const lavalinkManager = moduleRef.get<LavalinkManager>(LavalinkManager);
+		const lavalinkManager = moduleRef.get<LavalinkManager>(LAVALINK_MANAGER);
 		expect(lavalinkManager).toBeInstanceOf(LavalinkManager);
 		expect(mockPlayerSaver.getSessions).toHaveBeenCalled();
 	});
@@ -118,7 +118,7 @@ describe('LavalinkManagerProvider', () => {
 			]
 		}).compile();
 
-		const lavalinkManager = moduleRef.get<LavalinkManager>(LavalinkManager);
+		const lavalinkManager = moduleRef.get<LavalinkManager>(LAVALINK_MANAGER);
 		expect(lavalinkManager).toBeInstanceOf(LavalinkManager);
 		expect(mockPlayerSaver.getSessions).toHaveBeenCalled();
 	});
@@ -159,7 +159,7 @@ describe('LavalinkManagerProvider', () => {
 			]
 		}).compile();
 
-		const lavalinkManager = moduleRef.get<LavalinkManager>(LavalinkManager);
+		const lavalinkManager = moduleRef.get<LavalinkManager>(LAVALINK_MANAGER);
 		expect(lavalinkManager).toBeInstanceOf(LavalinkManager);
 		expect(mockPlayerSaver.getSessions).toHaveBeenCalled();
 	});

--- a/test/providers/lavalink-node-manager.provider.spec.ts
+++ b/test/providers/lavalink-node-manager.provider.spec.ts
@@ -2,6 +2,7 @@ import { NodeManager, LavalinkManager } from 'lavalink-client';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { LavalinkNodeManagerProvider } from '../../src/providers/lavalink-node-manager.provider.js';
+import { LAVALINK_MANAGER, LAVALINK_NODE_MANAGER } from '../../src/constants/index.js';
 
 describe('LavalinkNodeManagerProvider', () => {
 	let moduleRef: TestingModule;
@@ -21,11 +22,11 @@ describe('LavalinkNodeManagerProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkNodeManagerProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const nodeManager = moduleRef.get<NodeManager>(NodeManager);
+		const nodeManager = moduleRef.get<NodeManager>(LAVALINK_NODE_MANAGER);
 		expect(nodeManager).toBe(mockNodeManager);
 	});
 
@@ -37,11 +38,11 @@ describe('LavalinkNodeManagerProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkNodeManagerProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const nodeManager = moduleRef.get<NodeManager>(NodeManager);
+		const nodeManager = moduleRef.get<NodeManager>(LAVALINK_NODE_MANAGER);
 		expect(nodeManager).toBeNull();
 	});
 
@@ -53,11 +54,11 @@ describe('LavalinkNodeManagerProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkNodeManagerProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const nodeManager = moduleRef.get<NodeManager>(NodeManager);
+		const nodeManager = moduleRef.get<NodeManager>(LAVALINK_NODE_MANAGER);
 		expect(nodeManager).toBeUndefined();
 	});
 });

--- a/test/providers/lavalink-providers.spec.ts
+++ b/test/providers/lavalink-providers.spec.ts
@@ -3,11 +3,16 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Client } from 'discord.js';
 
 import {
+	LAVALINK_MANAGER,
+	LAVALINK_NODE_MANAGER,
+	LAVALINK_UTILS,
+	PlayerStore
+} from '../../src/constants/index.js';
+import {
 	PlayerManagerService,
 	PlayerSaverService,
 	LAVALINK_MODULE_OPTIONS
 } from '../../src/index.js';
-import { PlayerStore } from '../../src/constants/index.js';
 
 describe('Lavalink Providers', () => {
 	const mockLavalink = {
@@ -59,9 +64,9 @@ describe('Lavalink Providers', () => {
 	beforeAll(async () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
-				{ provide: ManagerUtils, useValue: mockLavalink.utils },
-				{ provide: LavalinkManager, useValue: mockLavalink.lavalinkManager },
-				{ provide: NodeManager, useValue: mockLavalink.nodeManager },
+				{ provide: LAVALINK_UTILS, useValue: mockLavalink.utils },
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalink.lavalinkManager },
+				{ provide: LAVALINK_NODE_MANAGER, useValue: mockLavalink.nodeManager },
 				{ provide: PlayerManagerService, useValue: mockLavalink.playerManager },
 				{ provide: PlayerSaverService, useValue: mockLavalink.playerSaver },
 				{ provide: PlayerStore, useValue: mockPlayerStore },
@@ -76,17 +81,17 @@ describe('Lavalink Providers', () => {
 	});
 
 	it('should provide the LavalinkUtils instance from Lavalink', () => {
-		const utils = moduleRef.get<ManagerUtils>(ManagerUtils);
+		const utils = moduleRef.get<ManagerUtils>(LAVALINK_UTILS);
 		expect(utils).toBe(mockLavalink.utils);
 	});
 
 	it('should provide the LavalinkManager instance from Lavalink', () => {
-		const manager = moduleRef.get<LavalinkManager>(LavalinkManager);
+		const manager = moduleRef.get<LavalinkManager>(LAVALINK_MANAGER);
 		expect(manager).toBe(mockLavalink.lavalinkManager);
 	});
 
 	it('should provide the LavalinkNodeManager instance from Lavalink', () => {
-		const nodeManager = moduleRef.get<NodeManager>(NodeManager);
+		const nodeManager = moduleRef.get<NodeManager>(LAVALINK_NODE_MANAGER);
 		expect(nodeManager).toBe(mockLavalink.nodeManager);
 	});
 

--- a/test/providers/lavalink-utils.provider.spec.ts
+++ b/test/providers/lavalink-utils.provider.spec.ts
@@ -2,6 +2,7 @@ import { ManagerUtils, LavalinkManager } from 'lavalink-client';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { LavalinkUtilsProvider } from '../../src/providers/lavalink-utils.provider.js';
+import { LAVALINK_MANAGER, LAVALINK_UTILS } from '../../src/constants/index.js';
 
 describe('LavalinkUtilsProvider', () => {
 	let moduleRef: TestingModule;
@@ -21,11 +22,11 @@ describe('LavalinkUtilsProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkUtilsProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const utils = moduleRef.get<ManagerUtils>(ManagerUtils);
+		const utils = moduleRef.get<ManagerUtils>(LAVALINK_UTILS);
 		expect(utils).toBe(mockUtils);
 	});
 
@@ -37,11 +38,11 @@ describe('LavalinkUtilsProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkUtilsProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const utils = moduleRef.get<ManagerUtils>(ManagerUtils);
+		const utils = moduleRef.get<ManagerUtils>(LAVALINK_UTILS);
 		expect(utils).toBeNull();
 	});
 
@@ -53,11 +54,11 @@ describe('LavalinkUtilsProvider', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				LavalinkUtilsProvider,
-				{ provide: LavalinkManager, useValue: mockLavalinkManager }
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager }
 			]
 		}).compile();
 
-		const utils = moduleRef.get<ManagerUtils>(ManagerUtils);
+		const utils = moduleRef.get<ManagerUtils>(LAVALINK_UTILS);
 		expect(utils).toBeUndefined();
 	});
 });

--- a/test/services/resuming-handler.service.spec.ts
+++ b/test/services/resuming-handler.service.spec.ts
@@ -1,5 +1,5 @@
-import { LavalinkManager, NodeManager, Player } from 'lavalink-client';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Player } from 'lavalink-client';
 import { Client } from 'discord.js';
 
 import {
@@ -7,8 +7,8 @@ import {
 	PlayerManagerService,
 	PlayerSaverService
 } from '../../src/services/index.js';
+import { LAVALINK_MANAGER, LAVALINK_NODE_MANAGER, PlayerStore } from '../../src/constants/index.js';
 import { LAVALINK_MODULE_OPTIONS } from '../../src/necord-lavalink.module-definition.js';
-import { PlayerStore } from '../../src/constants/index.js';
 
 describe('ResumingHandlerService', () => {
 	let moduleRef: TestingModule;
@@ -65,9 +65,9 @@ describe('ResumingHandlerService', () => {
 		moduleRef = await Test.createTestingModule({
 			providers: [
 				ResumingHandlerService,
-				{ provide: NodeManager, useValue: mockNodeManager },
+				{ provide: LAVALINK_NODE_MANAGER, useValue: mockNodeManager },
 				{ provide: PlayerManagerService, useValue: mockPlayerManager },
-				{ provide: LavalinkManager, useValue: mockLavalinkManager },
+				{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager },
 				{ provide: Client, useValue: mockClient },
 				{ provide: PlayerSaverService, useValue: mockPlayerSaver },
 				{ provide: PlayerStore, useValue: mockStore },
@@ -174,9 +174,9 @@ describe('ResumingHandlerService', () => {
 			moduleRef = await Test.createTestingModule({
 				providers: [
 					ResumingHandlerService,
-					{ provide: NodeManager, useValue: mockNodeManager },
+					{ provide: LAVALINK_NODE_MANAGER, useValue: mockNodeManager },
 					{ provide: PlayerManagerService, useValue: mockPlayerManager },
-					{ provide: LavalinkManager, useValue: mockLavalinkManager },
+					{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager },
 					{ provide: Client, useValue: mockClient },
 					{ provide: PlayerSaverService, useValue: mockPlayerSaver },
 					{ provide: PlayerStore, useValue: mockStore },
@@ -417,9 +417,9 @@ describe('ResumingHandlerService', () => {
 			moduleRef = await Test.createTestingModule({
 				providers: [
 					ResumingHandlerService,
-					{ provide: NodeManager, useValue: mockNodeManager },
+					{ provide: LAVALINK_NODE_MANAGER, useValue: mockNodeManager },
 					{ provide: PlayerManagerService, useValue: mockPlayerManager },
-					{ provide: LavalinkManager, useValue: mockLavalinkManager },
+					{ provide: LAVALINK_MANAGER, useValue: mockLavalinkManager },
 					{ provide: Client, useValue: mockClient },
 					{ provide: PlayerSaverService, useValue: mockPlayerSaver },
 					{ provide: PlayerStore, useValue: mockStore },


### PR DESCRIPTION
## Problem

`@necord/lavalink` registers its providers using **classes from `lavalink-client` as DI tokens**:

| File | Token |
|---|---|
| `src/providers/lavalink-manager.provider.ts` | `LavalinkManager` |
| `src/providers/lavalink-node-manager.provider.ts` | `NodeManager` |
| `src/providers/lavalink-utils.provider.ts` | `ManagerUtils` |

The package itself is published as **CommonJS only** (no `type`, no `exports`, no `.mjs` output),
while `lavalink-client` is dual-format:

```json
"exports": {
  ".": { "require": "./dist/index.cjs", "import": "./dist/index.mjs" }
}
```

So in an ESM application the two sides load two different physical files:

- `@necord/lavalink` (CJS) → `require("lavalink-client")` → `dist/index.cjs` → class **A**
- the application (ESM)    → `import  "lavalink-client"` → `dist/index.mjs` → class **B**

Nest matches providers by **reference identity**, and `A !== B`, so the container throws:

```
UnknownDependenciesException: Nest can't resolve dependencies of the
LavalinkNodeEvents (ConfigService, UserManager, ?). Please make sure that the
argument NodeManager at index [2] is available in the MusicModule module.
```

This never surfaced while consumer applications were CommonJS, because both sides then
resolved to the exact same file.

### Reproduction

```js
node --input-type=module -e '
const esm = await import("lavalink-client");
const { createRequire } = await import("node:module");
const cjs = createRequire(process.cwd()+"/x.js")("lavalink-client");
console.log("NodeManager    ESM === CJS ?", esm.NodeManager    === cjs.NodeManager);
console.log("LavalinkManager ESM === CJS ?", esm.LavalinkManager === cjs.LavalinkManager);
'
```

```
NodeManager    ESM === CJS ? false
LavalinkManager ESM === CJS ? false
```

Two objects, same class, different identity. That is the bug.

## Why a class reference can never be a safe DI token here

A class object is created once **per evaluated copy of the module that declares it**. Node
evaluates the CJS and the ESM build of a dual-format package independently, so every `class`
in `lavalink-client` exists twice in the same process, with the same name, the same shape and
different identity. Nest's injector is a `Map` keyed by reference, so a token produced by one
copy can never match a lookup made with the other. Nothing in userland can bridge that: the
consumer cannot force the library into a single format, and `peerDependencies` cannot express
it either.

The same reasoning rules out `Symbol()`: a plain symbol is also created per module copy, so it
diverges exactly like a class does. What is safe is a token resolved **by key** rather than by
reference — this PR uses `Symbol.for()`, which looks the key up in the process-wide global
symbol registry, so every copy of this package resolves the very same symbol.

## Changes

- New tokens in `src/constants/lavalink.tokens.ts`:
  - `LAVALINK_MANAGER` → `Symbol.for('NECORD_LAVALINK_MANAGER')`
  - `LAVALINK_NODE_MANAGER` → `Symbol.for('NECORD_LAVALINK_NODE_MANAGER')`
  - `LAVALINK_UTILS` → `Symbol.for('NECORD_LAVALINK_UTILS')`
- `PlayerStore` moved from `Symbol('PlayerStore')` to `Symbol.for('NECORD_LAVALINK_PLAYER_STORE')`
  for the same reason — a plain symbol is not stable across module copies.
- New inject decorators in `src/decorators/`: `@InjectLavalinkManager()`, `@InjectNodeManager()`,
  `@InjectManagerUtils()`, `@InjectPlayerStore()`.
- Providers register under the tokens; every internal injection site now uses the decorators
  (module constructor, listeners module, `NecordLavalinkService`, `PlayerManagerService`,
  `PlayerSaverService`, `ResumingHandlerService`).
- README documents the token/decorator API and the reason class injection is gone.
- New `test/constants/lavalink.tokens.spec.ts` locks the property that fixes the bug:
  `Symbol.keyFor(token)` returns the key (i.e. the token really is registry-backed, not a plain
  `Symbol()`), and `Symbol.for(key) === token`.

### Breaking change

Injecting by class type is no longer supported:

```ts
// before
constructor(private readonly nodeManager: NodeManager) {}

// after
constructor(@InjectNodeManager() private readonly nodeManager: NodeManager) {}
```

Keeping the class tokens registered in parallel as `useExisting` aliases was considered and
deliberately dropped: the alias only ever helps CommonJS consumers (whose class reference
happens to match ours), it cannot help the ESM consumers this PR is about, and it would keep a
broken pattern alive in the public API. Landing this as a major is the honest option.

`discord.js` and `necord` are **not** affected — `discord.js` points both its `import` and
`require` conditions at the same physical file (`./src/index.js`), and `necord` is CommonJS
only, so `Client` remains a single class object in every consumer. Only `lavalink-client`
ships two evaluated copies.

### `peerDependencies` are intentionally untouched

`"lavalink-client": "^2.6.1"` is already correct and stays as is. A peer range prevents
duplicate **versions** — two different releases of the library in one tree. This bug is a
duplicate **format** — one single version, loaded twice as CJS and as ESM. No peer range,
however strict, can prevent that, and no change to it would have fixed this issue. Please do
not conflate the two when reviewing.

### On shipping a dual CJS+ESM build

Not included here. It is what the ecosystem expects and is worth doing on its own merits, but
it does not fix this problem: an application that mixes formats can still end up with two
copies of `lavalink-client`, and a dual build of *this* package would additionally give it two
copies of its own tokens. Registry symbols are what makes the tokens survive either scenario,
which is why they land first.

## Validation

1. **Build** — `npm run build` (tsc) succeeds.
2. **ESM consumer** — a NestJS app with `"type": "module"` and `moduleResolution: nodenext`,
   importing `NodeManager` from the ESM build of `lavalink-client` and injecting it with
   `@InjectNodeManager()`:

   ```
   ESM app with forRoot()      : bootstrapped
   NodeManager                 : NodeManager
   LavalinkManager             : LavalinkManager
   ManagerUtils                : ManagerUtils
   nodeManager is manager.nodeManager: true
   ```

   The full `NecordLavalinkModule.forRoot()` graph boots — module constructor, listeners
   module and resuming handler included. In the same app, the pre-fix pattern (provider
   registered under the CJS class, injected by ESM type) still fails exactly as reported:

   ```
   Nest can't resolve dependencies of the LavalinkNodeEvents (?). Please make sure that the
   argument NodeManager at index [0] is available in the MusicModule module.
   ```

   Note that `nodeManager instanceof NodeManager` is `false` in the ESM app — the two class
   objects still diverge, as they must. The point of the fix is that DI no longer depends on it.
3. **CJS consumer** — unchanged behaviour, no regression:

   ```
   CJS app bootstrapped        : true
   NodeManager injected        : NodeManager
   instanceof CJS NodeManager  : true
   ```
4. **Test suite** — 15 suites, 85 tests passing; ESLint clean.

   ⚠️ Pre-existing and unrelated to this PR: `npm test` currently fails on `master` for every
   suite (14/14), verified on a clean `origin/master` worktree. Two independent causes, both
   from recent dev-dependency bumps:

   - `@nestjs/*@12.0.1` (#606) is **ESM-only** (`"type": "module"`), and Jest's CommonJS
     transform cannot load it on Node 22 — `Must use import to load ES Module:
     node_modules/@nestjs/testing/index.js`.
   - `typescript@7.0.2` is not supported by `ts-jest@29` ("does not expose the JavaScript
     compiler API required by ts-jest") nor by `typescript-eslint` ("does not support TS 7.0").
     `npm install` also needs `--legacy-peer-deps` for the same reason.

   The runs reported above were made with `@nestjs/*@11.2.2` and `typescript@5.9.3` installed
   locally (`--no-save`, `package.json` and lockfile untouched), which is the last combination
   where the suite executes at all. Both deserve their own fix.

   Worth noting that NestJS shipping ESM-only from v12 makes this PR more urgent, not less: the
   ESM consumer this fixes is where the ecosystem is heading, and every such application hits
   the `UnknownDependenciesException` today.
